### PR TITLE
Accept JSON in `curl` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ go run cmd/dashi-api/main.go
 And make some requests to see what the results look like:
 
 ```
-curl --silent -H 'Content-Type: application/json' localhost:8080 | jq .
-curl --silent -H 'Content-Type: application/json' localhost:8080/domain | jq .
-curl --silent -H 'Content-Type: application/json' localhost:8080/domain%20ie | jq .
+curl --silent -H 'Accept: application/json' localhost:8080 | jq .
+curl --silent -H 'Accept: application/json' localhost:8080/domain | jq .
+curl --silent -H 'Accept: application/json' localhost:8080/domain%20ie | jq .
 ```


### PR DESCRIPTION
Can add the `Content-Type` header back in, but needed `Accept` else requests were failing with `415 Unsupported Media Type`